### PR TITLE
Reference correct redis secret name for dev

### DIFF
--- a/helm-charts/_commons/values.dev.yaml
+++ b/helm-charts/_commons/values.dev.yaml
@@ -7,7 +7,7 @@ image:
 # settings for ingest
 keyServiceURL: "key-service-core-dev.core-dev.svc.cluster.local:8095"
 kafkaURL: "kafka.core-dev.svc.cluster.local:9092"
-redisSecretName: "redis-secrets"
+redisSecretName: "ubs.redis"
 serverUuid: "9d3c78ff-22f3-4441-a5d1-85c636d486ff"
 
 redis:


### PR DESCRIPTION
This change was already migrated on demo, but not yet on the dev deployment